### PR TITLE
add script for SF Memory (Nintendo Power)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Currently available:
 * `loadrom.py` - send ROM to unit over USB (will add valid header as necessary)
 * `clienttest.py` - test script: retrieve and show region of cart memory (also test r/w speed)
 * `dumptest.py` - test script: dump ROM and SRAM images from a cart
+* `np_dir.py` - show directory of SF Memory (Nintendo Power)
+* `np_dump.py` - dump individual ROM and SRAM images from SF Memory (Nintendo Power)
+* `np_dump_all.py` - dump whole Flash and SRAM images from SF Memory (Nintendo Power)
 
 The `loadrom` script is to be used with the USB transfer option on the Super UFO main menu. Other scripts communicate with the server program after it's running on the console.
 

--- a/scripts/np_dir.py
+++ b/scripts/np_dir.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import roswell.usbclient as usbclient
+
+def write_byte(addr, value):
+	c.write_cart(addr, value.to_bytes(1, 'little'))
+
+def read_byte(addr):
+	return c.read_cart(addr, 1)[0]
+
+def read_word(addr):
+	tmp = c.read_cart(addr, 2)
+	return (tmp[1] << 8) | tmp[0]
+
+def read_string(addr, len, encoding):
+	return c.read_cart(addr, len).tobytes().decode(encoding, 'replace').strip("\x00")
+
+def wakeup():
+	write_byte(0x2400, 0x09)
+	dummy = read_byte(0x2400)
+	write_byte(0x2401, 0x28)
+	write_byte(0x2401, 0x84)
+	write_byte(0x2400, 0x06)
+	write_byte(0x2400, 0x39)
+
+def read_reset(bank):
+	write_byte(bank << 16 | 0xAAAA, 0xAA)
+	write_byte(bank << 16 | 0x5554, 0x55)
+	write_byte(bank << 16 | 0xAAAA, 0xF0)
+
+def read_dir(base):
+	index = read_byte(base + 0)
+	if index == 0xFF:
+		return
+
+	print("")
+	print("Directory index        : %d" % index)
+	print("First FLASH block      : %d" % read_byte(base + 0x0001))
+	print("First SRAM block       : %d" % read_byte(base + 0x0002))
+	print("Number of FLASH blocks : %d" % (read_word(base + 0x0003) >> 2))
+	print("Number of SRAM blocks  : %d" % (read_word(base + 0x0005) >> 4))
+	print("Gamecode               : %s" % read_string(base + 0x0007, 12, 'ascii'))
+	print("Title                  : %s" % read_string(base + 0x0013, 44, 'shift-jis'))
+	print("Date                   : %s" % read_string(base + 0x01BF, 10, 'ascii'))
+	print("Time                   : %s" % read_string(base + 0x01C9, 8, 'ascii'))
+	print("Law                    : %s" % read_string(base + 0x01D1, 8, 'ascii'))
+
+c = usbclient.USBClient()
+c.open()
+print("opened USB device successfully")
+
+tmp = read_byte(0x2400)
+if tmp == 0x7D:
+	wakeup()
+elif tmp != 0x2A:
+	print("SF memory is not detected")
+	exit
+
+print("SF memory is detected")
+
+#HIROM:ALL
+write_byte(0x2400, 0x04)
+read_reset(0xC0)
+
+for base in range(0xC60000, 0xC70000, 0x2000):
+	read_dir(base)

--- a/scripts/np_dump.py
+++ b/scripts/np_dump.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import roswell.usbclient as usbclient
+import array
+
+def write_byte(addr, value):
+	c.write_cart(addr, value.to_bytes(1, 'little'))
+
+def read_byte(addr):
+	return c.read_cart(addr, 1)[0]
+
+def read_word(addr):
+	tmp = c.read_cart(addr, 2)
+	return (tmp[1] << 8) | tmp[0]
+
+def read_string(addr, len, encoding):
+	return c.read_cart(addr, len).tobytes().decode(encoding, 'replace').strip("\x00")
+
+def wakeup():
+	write_byte(0x2400, 0x09)
+	dummy = read_byte(0x2400)
+	write_byte(0x2401, 0x28)
+	write_byte(0x2401, 0x84)
+	write_byte(0x2400, 0x06)
+	write_byte(0x2400, 0x39)
+
+def read_reset(bank):
+	write_byte(bank << 16 | 0xAAAA, 0xAA)
+	write_byte(bank << 16 | 0x5554, 0x55)
+	write_byte(bank << 16 | 0xAAAA, 0xF0)
+
+def save(filename, data):
+	with open(filename, 'wb') as f:
+		data.tofile(f)
+		print("wrote %s successfully" % filename)
+
+def dump(base):
+	index = read_byte(base + 0)
+	if index == 0xFF:
+		return
+
+	first_flash_block = read_byte(base + 0x01)
+	first_sram_block  = read_byte(base + 0x02)
+	flash_blocks      = read_word(base + 0x03) >> 2
+	sram_blocks       = read_word(base + 0x05) >> 4
+	title             = read_string(base + 0x13, 44, 'shift-jis')
+
+	first_bank = 0xC0 + (first_flash_block << 3)
+	last_bank = first_bank + (flash_blocks << 3) - 1
+	data = c.read_banks(first_bank, last_bank, 0x0000, 0xFFFF)
+	save(title + ".sfc", data)
+
+	sram_start = first_sram_block << 11
+	sram_end = sram_start + (sram_blocks << 11)
+	data = sram[sram_start:sram_end]
+	save(title + ".srm", data)
+
+c = usbclient.USBClient()
+c.open()
+print("opened USB device successfully")
+
+tmp = read_byte(0x2400)
+if tmp == 0x7D:
+	wakeup()
+elif tmp != 0x2A:
+	print("SF memory is not detected")
+	exit
+
+print("SF memory is detected")
+
+#HIROM:ALL
+write_byte(0x2400, 0x04)
+read_reset(0xC0)
+read_reset(0xE0)
+
+sram = c.read_banks(0x20, 0x23, 0x6000, 0x7FFF)
+for base in range(0xC60000, 0xC70000, 0x2000):
+	dump(base)

--- a/scripts/np_dump_all.py
+++ b/scripts/np_dump_all.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import roswell.usbclient as usbclient
+
+def write_byte(addr, value):
+	c.write_cart(addr, value.to_bytes(1, 'little'))
+
+def read_byte(addr):
+	return c.read_cart(addr, 1)[0]
+
+def wakeup():
+	write_byte(0x2400, 0x09)
+	dummy = read_byte(0x2400)
+	write_byte(0x2401, 0x28)
+	write_byte(0x2401, 0x84)
+	write_byte(0x2400, 0x06)
+	write_byte(0x2400, 0x39)
+
+def read_reset(bank):
+	write_byte(bank << 16 | 0xAAAA, 0xAA)
+	write_byte(bank << 16 | 0x5554, 0x55)
+	write_byte(bank << 16 | 0xAAAA, 0xF0)
+
+def show_hidden(bank):
+	write_byte(bank << 16, 0x38)
+	write_byte(bank << 16, 0xD0)
+	write_byte(bank << 16, 0x71)
+	while True:
+		dummy = read_byte(bank << 16 | 0x0004)
+		if dummy & 0x80:
+			break
+	write_byte(bank << 16, 0x72)
+	write_byte(bank << 16, 0x75)
+
+def save(filename, data):
+	with open(filename, 'wb') as f:
+		data.tofile(f)
+		print("wrote %s successfully" % filename)
+
+c = usbclient.USBClient()
+c.open()
+print("opened USB device successfully")
+
+tmp = read_byte(0x2400)
+if tmp == 0x7D:
+	wakeup()
+elif tmp != 0x2A:
+	print("SF memory is not detected")
+	exit
+
+print("SF memory is detected")
+
+#HIROM:ALL
+write_byte(0x2400, 0x04)
+
+# dump boot sector in bank $C0
+show_hidden(0xC0)
+data = c.read_cart(0xC0FF00, 256)
+save("bootsect_C0.bin", data)
+
+# dump boot sector in bank $E0
+show_hidden(0xE0)
+data = c.read_cart(0xE0FF00, 256)
+save("bootsect_E0.bin", data)
+
+# dump $0000-FFFF in banks $C0-FF
+read_reset(0xC0)
+read_reset(0xE0)
+data = c.read_banks(0xC0, 0xFF, 0x0000, 0xFFFF)
+save("np.sfc", data)
+
+# dump $6000-7FFF in banks $20-23
+data = c.read_banks(0x20, 0x23, 0x6000, 0x7FFF)
+save("np.srm", data)


### PR DESCRIPTION
https://forums.nesdev.org/viewtopic.php?t=11453&start=205

> I ended up using Revenants great roswell for Super Ufo Pro 8 and wrote a python script that implements Nintendo Power support for that instead.

I found the above comment by d4s on NesDev.
But I could not find d4s script so I made my own.